### PR TITLE
Add spec for the 'Automatically plan meeting' feature

### DIFF
--- a/features/automatically-plan-meeting.feature
+++ b/features/automatically-plan-meeting.feature
@@ -1,0 +1,9 @@
+Feature: Automatically plan meeting
+  As a meeting participant
+  I want the system to automatically plan a prospective meeting after a successful scheduled one
+  So that I don't have to worry about planning meetings
+
+  Scenario: Plan prospective meeting
+    Given there is no future prospective or scheduled meeting
+    When a preconfigured interval has passed
+    Then the system plans a prospective meeting


### PR DESCRIPTION
While we're add it, here's another one! This time for `P1` as described in #2.
